### PR TITLE
Atualização de tipos para explicitar parâmetros opcionais

### DIFF
--- a/squid_logger.d.ts
+++ b/squid_logger.d.ts
@@ -5,13 +5,13 @@ declare module 'squid-logger' {
     googleCloudCredentials: string, 
     environment: string, 
     applicationName: string,
-     version: string, 
-     stdOutLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
-     cloudLoggingLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
-     sensitiveFieldsObj: Record<string, unknown>, 
-     applicationRepository?: string, 
-     applicationRevisionId?: string
-     ): void;
+    version: string, 
+    stdOutLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
+    cloudLoggingLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
+    sensitiveFieldsObj: Record<string, unknown>, 
+    applicationRepository?: string, 
+    applicationRevisionId?: string
+  ): void;
   export function Trace(dataToLog: any, req?: any, res?: any, user?: any, skipLog: boolean = false): void;
   export function Debug(dataToLog: any, req?: any, res?: any, user?: any, skipLog: boolean = false): void;
   export function Info(dataToLog: any,  req?: any, res?: any, user?: any, skipLog: boolean = false): void;

--- a/squid_logger.d.ts
+++ b/squid_logger.d.ts
@@ -1,13 +1,25 @@
-declare module 'squid-logger'{
-  export function Configure(stdOutLogLevel: any, cloudLoggingLogLevel: any, sensitiveFieldsObj: any): any;
-  export function Trace(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Debug(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Info(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Warn(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Error(err: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Fatal(err: any, req: any, res: any, user: any, skipLog: any): void;
+declare module 'squid-logger' {
+
+  export function Configure(
+    projectId: string, 
+    googleCloudCredentials: string, 
+    environment: string, 
+    applicationName: string,
+     version: string, 
+     stdOutLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
+     cloudLoggingLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
+     sensitiveFieldsObj: Record<string, unknown>, 
+     applicationRepository?: string, 
+     applicationRevisionId?: string
+     ): void;
+  export function Trace(dataToLog: any, req?: any, res?: any, user?: any, skipLog: boolean = false): void;
+  export function Debug(dataToLog: any, req?: any, res?: any, user?: any, skipLog: boolean = false): void;
+  export function Info(dataToLog: any,  req?: any, res?: any, user?: any, skipLog: boolean = false): void;
+  export function Warn(dataToLog: any,  req?: any, res?: any, user?: any, skipLog: boolean = false): void;
+  export function Error(err: any,       req?: any, res?: any, user?: any, skipLog: boolean = false): void;
+  export function Fatal(err: any,       req?: any, res?: any, user?: any, skipLog: boolean = false): void;
   /**
-   * @deprecated This funcction should not be used. Use the "Error" function instead.
+   * @deprecated This function should not be used. Use the "Error" function instead.
    */
   export function ReportError(err: any, req: any, res: any, user: any): void;
 }


### PR DESCRIPTION
Hoje, os tipos definidos dos métodos marcam todos os parâmetros como obrigatórios. Isso força quem está usando a escrever códigos do tipo:
```ts
SquidLogger.Fatal(SquidError.Create(PubSubSubscriptionError, error), null, null, null, null)
```

A atualização de tipos desse PR permite que os métodos de log seja chamado apenas com os parâmetros obrigatórios.

Também foi atualizado o método de configuração para refletir melhor os tipos necessários, evitando erros:
![image](https://user-images.githubusercontent.com/22063042/227654579-367d24e1-6967-46cb-8526-7b629cd38285.png)
