### PR TITLE
fix: updated types on ts file for optional parameters

### DIFF
--- a/squid_logger.d.ts
+++ b/squid_logger.d.ts
@@ -1,13 +1,18 @@
 declare module 'squid-logger'{
-  export function Configure(stdOutLogLevel: any, cloudLoggingLogLevel: any, sensitiveFieldsObj: any): any;
-  export function Trace(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Debug(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Info(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Warn(dataToLog: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Error(err: any, req: any, res: any, user: any, skipLog: any): void;
-  export function Fatal(err: any, req: any, res: any, user: any, skipLog: any): void;
+  export function Configure(
+    stdOutLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
+    cloudLoggingLogLevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal' | null, 
+    sensitiveFieldsObj: Record<string, unknown>, 
+    ): void;
+
+  export function Trace(dataToLog: any, req: any, res: any, user: any, skipLog: boolean): void;
+  export function Debug(dataToLog: any, req: any, res: any, user: any, skipLog: boolean): void;
+  export function Info(dataToLog: any,  req: any, res: any, user: any, skipLog: boolean): void;
+  export function Warn(dataToLog: any,  req: any, res: any, user: any, skipLog: boolean): void;
+  export function Error(err: any,       req: any, res: any, user: any, skipLog: boolean): void;
+  export function Fatal(err: any,       req: any, res: any, user: any, skipLog: boolean): void;
   /**
-   * @deprecated This funcction should not be used. Use the "Error" function instead.
+   * @deprecated This function should not be used. Use the "Error" function instead.
    */
   export function ReportError(err: any, req: any, res: any, user: any): void;
 }


### PR DESCRIPTION
Hoje, os tipos definidos dos métodos marcam todos os parâmetros como obrigatórios. Isso força quem está usando a escrever códigos do tipo:

`SquidLogger.Fatal(SquidError.Create(PubSubSubscriptionError, error), null, null, null, null)`

A atualização de tipos desse PR permite que os métodos de log seja chamado apenas com os parâmetros obrigatórios.

Também foi atualizado o método de configuração para refletir melhor os tipos necessários, evitando erros:
![image](https://user-images.githubusercontent.com/33484438/228027812-29a265be-1e23-4c90-ab01-7a3e7b3c848b.png)

