### PR TITLE
Tratamento de exceções fora de escopo padrão

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-logger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lib que loga e reporta errors para Google Cloud",
   "main": "squid_logger.js",
   "scripts": {

--- a/squid_logger.js
+++ b/squid_logger.js
@@ -85,13 +85,21 @@ function Configure (stdOutLogLevel, cloudLoggingLogLevel, sensitiveFieldsObj)
         labels : { project_id : SquidObservabilityConfigs.projectId },
         type   : 'api'
       },
-      defaultCallback : err =>
+      defaultCallback : error =>
       {
-        if (err)
+        if (error)
           // eslint-disable-next-line no-console
-          console.log('Error occured: ' + err);
+          console.log(`Squid Logger | GCM logging error: ${error}`);
       },
       serviceContext : SquidObservabilityConfigs.serviceContext
+    });
+
+    // required due to the fact that some errors can be thrown outside the scope of the default callback
+    // see: https://github.com/googleapis/nodejs-logging-bunyan/issues/687
+    loggingBunyan.on('error', (error) =>
+    {
+      // eslint-disable-next-line no-console
+      console.log(`Squid Logger | Bunyan logging error: ${error}`);
     });
 
     // Create a Bunyan logger that streams to Cloud Logging


### PR DESCRIPTION
Corrige um problema onde algumas exceções (por exemplo de rejeição de montagem de logs devido ao tamanho dos dados exceder 256kb) acabaram estourando na API e fazendo ela finalizar devido a uma `uncaughtException`. 
Agora, esses "erros ao gerar log de erros" também viram apenas um log no console ao invés de travar a aplicação.

Exemplo de situação similar: https://github.com/googleapis/nodejs-logging-bunyan/issues/687